### PR TITLE
Add package.json & instructions how to install with NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ To view all the available flags, check the [gallery](all-flags.md).
 If you're using [React](https://reactjs.org), you may want to try the
 [react-circle-flags](https://www.npmjs.com/package/react-circle-flags) package.
 
+### NPM
+
+If you want to install this package as dependency, you can install it from this GitHub repository:
+
+```
+npm install --save https://github.com/HatScripts/circle-flags
+```
+
 ## Contributing
 
 To contribute, you need to have [svgo](https://github.com/svg/svgo) installed

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "circle-flags",
+  "version": "1.0.0",
+  "description": "A collection of circular SVG country flags.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HatScripts/circle-flags.git"
+  },
+  "keywords": [
+    "svg",
+    "country-flags",
+    "country",
+    "icons",
+    "circular",
+    "round",
+    "circle",
+    "minimal",
+    "design",
+    "flags",
+    "svg-icons",
+    "svgo",
+    "minimalist",
+    "minimalistic",
+    "countries",
+    "circle-flags",
+    "languages",
+    "states",
+    "circles",
+    "icon-pack"
+  ],
+  "author": "HatScripts <contact@hatscripts.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/HatScripts/circle-flags/issues"
+  },
+  "homepage": "https://github.com/HatScripts/circle-flags#readme"
+}


### PR DESCRIPTION
Rationale behind this pull request is that we have React Native project, and we want to ship the circle flags that are used in the application itself (e.g. we don't want to make request to Internet for the flags for sure). By creating package.json on this project allows adding it as a npm dependency, and using the circle flags from filesystem. We of course could have used this project as a GIT submodule, but handling dependencies via npm is somewhat better.

I could contribute to the community by creating a React Native package as well if we can get the dependency thing merged in! :-)