### PR TITLE
Add file extension to the LICENSE file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2022 HatScripts
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A collection of circular SVG country flags.
 
 ## Usage
 
-```
+```text
 https://hatscripts.github.io/circle-flags/flags/xx.svg
 ```
+
 (Where `xx` is the [ISO 3166-1 alpha-2 code](https://www.iso.org/obp/ui/#search/code/) of a country).
 
 For example, the following code:
+
 ```html
 <img src="https://hatscripts.github.io/circle-flags/flags/br.svg" width="48">
 <img src="https://hatscripts.github.io/circle-flags/flags/cn.svg" width="48">
@@ -42,7 +44,7 @@ If you're using [React](https://reactjs.org), you may want to try the
 
 If you want to install this package as a dependency, you can install it from this GitHub repository:
 
-```
+```sh
 npm install --save https://github.com/HatScripts/circle-flags
 ```
 
@@ -63,7 +65,7 @@ Then commit the changes, and submit them as a pull request.
 
 ### The color palette
 
-Submitted flags should conform to the following color palette.<br>
+Submitted flags should conform to the following color palette.<br/>
 Try to match the flag's original colors with the nearest color from the palette.
 
 * `#eeeeee`: white

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ Try to match the flag's original colors with the nearest color from the palette.
 * `#0052b4`: blue
 
 Special cases:
+
 * `#002266`: dark blue (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/td.svg" width="16"> Chad](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/td.svg), to differentiate from [<img src="https://hatscripts.github.io/circle-flags/flags/ro.svg" width="16"> Romania](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/ro.svg))
 * `#4a1f63`: purple (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/es-ib.svg" width="16"> Balearic Islands](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/es-ib.svg))
 * `#751a46`: dark pink (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/qa.svg" width="16"> Qatar](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/qa.svg))
 
 ## License
 
-This project is released under the [MIT license](LICENSE).
+This project is released under the [MIT license](LICENSE.md).


### PR DESCRIPTION
This makes it explicit that it's a text (markdown) file; and also allows formatting the title so it's rendered more prominently.