### PR TITLE
Add svgo as npm dependency and set up npm script to run it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Don't track the Node.js installation artifacts
+/node_modules/
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -55,14 +55,25 @@ npm install --save https://github.com/HatScripts/circle-flags
 
 ## Contributing
 
-To contribute, you need to have the latest version of [svgo](https://github.com/svg/svgo) installed.
+### Initial setup
+
+To contribute, you need to have the [Node.js](https://nodejs.org) JavaScript runtime installed,
+and the latest version of [svgo](https://github.com/svg/svgo).
+Once Node.js is set up, you can run the following command to install `svgo` in the circle-flags project directory:
+
+```sh
+npm install
+```
+
+### Making changes
 
 First, edit the relevant SVG files in the `flags/` directory.
 
-Then run `svgo` to optimize the SVG files:
+Then run the `svgo` wrapper script (defined in the `scripts` section of [package.json](./package.json)),
+which uses the locally-installed `svgo` executable to optimize the SVG files:
 
 ```sh
-svgo ./flags --recursive --config=svgo.config.js
+npm run svgo
 ```
 
 Then commit the changes, and submit them as a pull request.

--- a/package.json
+++ b/package.json
@@ -33,5 +33,11 @@
   "bugs": {
     "url": "https://github.com/HatScripts/circle-flags/issues"
   },
-  "homepage": "https://github.com/HatScripts/circle-flags#readme"
+  "homepage": "https://github.com/HatScripts/circle-flags#readme",
+  "devDependencies": {
+    "svgo": "^3.0.2"
+  },
+  "scripts": {
+    "svgo": "node_modules/.bin/svgo ./flags --recursive --config=svgo.config.js"
+  }
 }


### PR DESCRIPTION
Fixes #99. This allows making the svgo dependency explicit and locked to a working version, while also simplifying the commands for contributing to the project. 

|                | Before                                             | After          |
| -------------- | -------------------------------------------------- | -------------- |
| Install `svgo` | `npm install -g svgo`                              | `npm install`  |
| Run `svgo`     | `svgo ./flags --recursive --config=svgo.config.js` | `npm run svgo` |

I've updated the instructions in the README, taking care to describe what's going on at each step so there's no mysterious magic happening behind the scenes for those who are not familiar with Node.js projects.

~~(Btw, we should probably mention in the README that Node.js is required for contributing, since `svgo` is a Node.js project — wdyt @HatScripts?)~~ **Update**: done.
