### PR TITLE
Add solid-circle-flags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,32 +13,27 @@ https://hatscripts.github.io/circle-flags/flags/xx.svg
 For example, the following code:
 
 ```html
-<img src="https://hatscripts.github.io/circle-flags/flags/br.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/cn.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/gb.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/id.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/in.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/ng.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/ru.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/us.svg" width="48">
+<img src="https://hatscripts.github.io/circle-flags/flags/br.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/cn.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/gb.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/id.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/in.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/ng.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/ru.svg" width="48" />
+<img src="https://hatscripts.github.io/circle-flags/flags/us.svg" width="48" />
 ```
 
-...produces this:<br/><br/>
-<img src="https://hatscripts.github.io/circle-flags/flags/br.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/cn.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/gb.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/id.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/in.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/ng.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/ru.svg" width="48">
-<img src="https://hatscripts.github.io/circle-flags/flags/us.svg" width="48">
+...produces this:<br/><br/> <img src="https://hatscripts.github.io/circle-flags/flags/br.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/cn.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/gb.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/id.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/in.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/ng.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/ru.svg" width="48"> <img src="https://hatscripts.github.io/circle-flags/flags/us.svg" width="48">
 
 To view all the available flags, check [the gallery](https://hatscripts.github.io/circle-flags/gallery).
 
 ### React
 
-If you're using [React](https://reactjs.org), you may want to try the
-[react-circle-flags](https://www.npmjs.com/package/react-circle-flags) package.
+If you're using [React](https://reactjs.org), you may want to try the [react-circle-flags](https://www.npmjs.com/package/react-circle-flags) package.
+
+### SolidJS
+
+If you're using [SolidJS](https://www.solidjs.com/), you may want to try the [solid-circle-flags](https://www.npmjs.com/package/solid-circle-flags) package.
 
 ### NPM
 
@@ -51,7 +46,7 @@ npm install --save https://github.com/HatScripts/circle-flags
 ### Userscripts
 
 - [Google Translate: Filter & Flags](https://github.com/HatScripts/google-translate-filter-and-flags) - Filters languages and shows country flags on Google Translate
-- [Wiktionary: Filter & Flags](https://github.com/HatScripts/wiktionary-filter-and-flags) - Filters languages and shows country flags on Wiktionary 
+- [Wiktionary: Filter & Flags](https://github.com/HatScripts/wiktionary-filter-and-flags) - Filters languages and shows country flags on Wiktionary
 
 ## Contributing
 
@@ -69,26 +64,25 @@ Then commit the changes, and submit them as a pull request.
 
 ### The color palette
 
-Submitted flags should conform to the following color palette.<br/>
-Try to match the flag's original colors with the nearest color from the palette.
+Submitted flags should conform to the following color palette.<br/> Try to match the flag's original colors with the nearest color from the palette.
 
-* `#eeeeee`: white
-* `#acabb1`: gray
-* `#333333`: black
-* `#a2001d`: dark red
-* `#d80027`: red
-* `#ff9811`: orange
-* `#ffda44`: yellow
-* `#6da544`: green
-* `#496e2d`: dark green
-* `#338af3`: light blue
-* `#0052b4`: blue
+- `#eeeeee`: white
+- `#acabb1`: gray
+- `#333333`: black
+- `#a2001d`: dark red
+- `#d80027`: red
+- `#ff9811`: orange
+- `#ffda44`: yellow
+- `#6da544`: green
+- `#496e2d`: dark green
+- `#338af3`: light blue
+- `#0052b4`: blue
 
 Special cases:
 
-* `#002266`: dark blue (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/td.svg" width="16"> Chad](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/td.svg), to differentiate from [<img src="https://hatscripts.github.io/circle-flags/flags/ro.svg" width="16"> Romania](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/ro.svg))
-* `#4a1f63`: purple (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/es-ib.svg" width="16"> Balearic Islands](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/es-ib.svg))
-* `#751a46`: dark pink (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/qa.svg" width="16"> Qatar](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/qa.svg))
+- `#002266`: dark blue (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/td.svg" width="16"> Chad](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/td.svg), to differentiate from [<img src="https://hatscripts.github.io/circle-flags/flags/ro.svg" width="16"> Romania](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/ro.svg))
+- `#4a1f63`: purple (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/es-ib.svg" width="16"> Balearic Islands](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/es-ib.svg))
+- `#751a46`: dark pink (only one usage: [<img src="https://hatscripts.github.io/circle-flags/flags/qa.svg" width="16"> Qatar](https://github.com/HatScripts/circle-flags/blob/gh-pages/flags/qa.svg))
 
 ## License
 


### PR DESCRIPTION
I created the SolidJS equivalent of react-circle-flags, which is solid-circle-flags. And added it to the README.