### PR TITLE
Add .gitattributes and .gitignore files for SVG handling and node_modules exclusion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.svg text diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/


### PR DESCRIPTION
(Split out from #145.)

The [`.gitignore` file](https://git-scm.com/docs/gitignore) should be self-explanatory :) it is also a [recommended good practice](https://github.com/github/gitignore/blob/86922aee426c32ffb6098f9a38c42da75169501e/Node.gitignore#L41).

As for the [`.gitattributes` configuration](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes) for `.svg` files, I added it because I noticed that git treats some variants of SVG files (e.g., if they lack the `xmlns` attrtribute) as regular (binary) images rather than as text files, resulting in diffs like this:

<img width="733" height="249" alt="image" src="https://github.com/user-attachments/assets/8fe79416-9d48-4842-a645-f3fa515c55f6" />

<p></p>

With the `.gitattributes` file as added in this PR, it will show the text-based diff, like this:

<img width="733" height="249" alt="image" src="https://github.com/user-attachments/assets/6b9128e7-509c-4dee-8be2-efb2e656a1e7" />
