### PR TITLE
Add flag for Valencia (spanish region)

### DIFF
--- a/flags/es-vc.svg
+++ b/flags/es-vc.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><mask id="a"><circle cx="256" cy="256" r="256" fill="#fff"/></mask><g mask="url(#a)"><path fill="#ffda44" d="M0 0h512v512H0z"/><path fill="#d80027" d="M111 57h401v57H111zm0 114h401v57H111zm0 114h401v56H111zm0 113h401v57H111z"/><path fill="#0052b4" d="M0 0h111v512H0z"/></g></svg>

--- a/gallery.md
+++ b/gallery.md
@@ -114,6 +114,7 @@ https://hatscripts.github.io/circle-flags/flags/xx.svg
   <div><img src="flags/es-ib.svg" width="96"/><p>Balearic Islands (<code>es-ib</code>)</p></div>
   <div><img src="flags/es-ml.svg" width="96"/><p>Melilla (<code>es-ml</code>)</p></div>
   <div><img src="flags/es-pv.svg" width="96"/><p>Basque Country (<code>es-pv</code>)</p></div>
+  <div><img src="flags/es-vc.svg" width="96"/><p>Valencia (<code>es-vc</code>)</p></div>
   <div><img src="flags/et.svg" width="96"/><p>Ethiopia (<code>et</code>)</p></div>
   <div><img src="flags/et-af.svg" width="96"/><p>Afar (<code>et-af</code>)</p></div>
   <div><img src="flags/et-am.svg" width="96"/><p>Amhara (<code>et-am</code>)</p></div>


### PR DESCRIPTION
Add simplified version of Valencian flag, an autonomous community of Spain.

<img width="1130" height="314" alt="image" src="https://github.com/user-attachments/assets/2cf8ad48-5b55-46e8-afe7-ec86801ad8c5" />

Source: https://es.wikipedia.org/wiki/Bandera_de_la_Comunidad_Valenciana#Versi%C3%B3n_simplificada